### PR TITLE
ncurses LFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ HEADER =
 OUT = bluetoothctl-ncurses
 CC = gcc
 FLAGS = -g -c -Wall
-LFLAGS = -lmenu -lncurses
+LFLAGS = -lmenu `pkg-config --libs ncurses`
 
 all: $(OBJS)
 	$(CC) -g $(OBJS) -o $(OUT) $(LFLAGS)


### PR DESCRIPTION
Fixes a compilation error due to undefined reference to `LINES`.

```
$  make
gcc -g -c -Wall main.c
gcc -g main.o -o bluetoothctl-ncurses -lmenu -lncurses
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.1.0/../../../../aarch64-unknown-linux-gnu/bin/ld: main.o: undefined reference
to symbol 'LINES'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.1.0/../../../../aarch64-unknown-linux-gnu/bin/ld: /lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [makefile:10: all] Error 1

$ pkg-config --libs ncurses
-lncurses -ltinfo
```